### PR TITLE
feat : 도형 다중 선택, 크기 조절, 위치 이동

### DIFF
--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -27,6 +27,10 @@ public class CanvasController extends MouseAdapter {
         canvasModel.setCurrentTool(tool);
     }
 
+    public Tool getCurrentTool() {
+        return canvasModel.getCurrentTool();
+    }
+
     public ArrayList<Shape> getShapes() {
         return canvasModel.getShapes();
     }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -44,6 +44,15 @@ public class CanvasController extends MouseAdapter {
         canvasModel.handleClick(x, y);
     }
 
+    public void mouseDragged(double x, double y, double dx, double dy) {
+        if(isResizing){
+            resizeSelectedShape(x, y);
+        }
+        else if(isDragging){
+            moveSelectedShapes(dx, dy);
+        }
+    }
+
     public void setCurrentTool(Tool tool) {
         canvasModel.setCurrentTool(tool);
     }
@@ -68,11 +77,9 @@ public class CanvasController extends MouseAdapter {
         canvasModel.resizeSelectedShape(x, y);
     }
 
-    public void moveSelectedShape(double dx, double dy) {
-        canvasModel.moveSelectedShape(dx, dy);
-    }
-
     public void moveSelectedShapes(double dx, double dy) {
         canvasModel.moveSelectedShapes(dx, dy);
     }
+
+    
 }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -43,4 +43,12 @@ public class CanvasController extends MouseAdapter {
     public Shape getSelectedShape() {
         return canvasModel.getSelectedShape();
     }
+
+    public void resizeSelectedShape(double x, double y) {
+        canvasModel.resizeSelectedShape(x, y);
+    }
+
+    public void moveSelectedShape(double dx, double dy) {
+        canvasModel.moveSelectedShape(dx, dy);
+    }
 }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -10,6 +10,8 @@ import miridih.observer.ShapeChangeListener;
 
 public class CanvasController extends MouseAdapter {
     private final CanvasModel canvasModel;
+    private boolean isResizing = false;
+    private boolean isDragging = false;
 
     public CanvasController(CanvasModel model) {
         canvasModel = model;
@@ -20,10 +22,24 @@ public class CanvasController extends MouseAdapter {
     }
 
     public void mousePressed(double x, double y) {
+        if(getCurrentTool() == Tool.SELECT ){
+            Shape selectedShape = getSelectedShape();
+            if(selectedShape != null && selectedShape.isOnHandle(x, y)){
+                isResizing = true;
+            }
+            else{
+                isDragging = true;
+            }
+        }
+        if(getCurrentTool() == Tool.MULTI_SELECT){
+            isDragging = true;
+        }
         canvasModel.setStart(x, y);
     }
 
     public void mouseReleased(double x, double y) {
+        isResizing = false;
+        isDragging = false;
         canvasModel.setEnd(x, y);
         canvasModel.handleClick(x, y);
     }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -44,11 +44,19 @@ public class CanvasController extends MouseAdapter {
         return canvasModel.getSelectedShape();
     }
 
+    public ArrayList<Shape> getSelectedShapes() {
+        return canvasModel.getSelectedShapes();
+    }
+
     public void resizeSelectedShape(double x, double y) {
         canvasModel.resizeSelectedShape(x, y);
     }
 
     public void moveSelectedShape(double dx, double dy) {
         canvasModel.moveSelectedShape(dx, dy);
+    }
+
+    public void moveSelectedShapes(double dx, double dy) {
+        canvasModel.moveSelectedShapes(dx, dy);
     }
 }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -76,8 +76,8 @@ public class CanvasModel {
 
     public void createShape() {
         Shape newShape = ShapeFactory.createShape(currentTool);
-        newShape.setStart(startX, startY);
-        newShape.setEnd(endX, endY);
+        newShape.setStart(Math.min(startX, endX), Math.min(startY, endY));
+        newShape.setEnd(Math.max(startX, endX), Math.max(startY, endY));
         if (currentTool != null) {
             newShape.setTool(currentTool);
             shapes.add(newShape);

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -10,7 +10,7 @@ import miridih.observer.ShapeChangeListener;
 
 public class CanvasModel {
     private ArrayList<Shape> shapes = new ArrayList<Shape>();
-    private Shape selectedShape = null;
+    private ArrayList<Shape> selectedShapes = new ArrayList<Shape>();
     private Tool currentTool = Tool.SELECT;
 
     private List<ShapeChangeListener> listeners = new ArrayList<>();
@@ -56,10 +56,25 @@ public class CanvasModel {
     }
 
     public void handleClick(double x, double y) {
+        Shape selectedShape = selectShape(x, y);
         if (currentTool == Tool.SELECT) {
-            selectedShape = selectShape(x, y);
-            System.out.println(selectedShape.getEndX());
-        } else {
+            selectedShapes.clear();
+            if(selectedShape != null){
+                selectedShapes.add(selectedShape);
+            }
+            
+        } 
+        else if(currentTool == Tool.MULTI_SELECT){
+            if(selectedShape != null){
+                if(selectedShapes.contains(selectedShape)){
+                    selectedShapes.remove(selectedShape);
+                }
+                else{
+                    selectedShapes.add(selectedShape);
+                }
+            }
+        }
+        else {
             createShape();
         }
     }
@@ -81,25 +96,37 @@ public class CanvasModel {
         if (currentTool != null) {
             newShape.setTool(currentTool);
             shapes.add(newShape);
-            selectedShape = newShape;
+            selectedShapes.add(newShape);
+            setCurrentTool(Tool.SELECT);
             notifyShapeChanged();
         }
     }
 
     public Shape getSelectedShape() {
-        return selectedShape;
+        return selectedShapes.get(0);
+    }
+
+    public ArrayList<Shape> getSelectedShapes() {
+        return selectedShapes;
     }
 
     public void moveSelectedShape(double dx, double dy) {
-        if (selectedShape != null) {
-            selectedShape.move(dx, dy);
+        if (selectedShapes.get(0) != null) {
+            selectedShapes.get(0).move(dx, dy);
             notifyShapeChanged();
         }
     }
 
+    public void moveSelectedShapes(double dx, double dy) {
+        for(Shape shape : selectedShapes){
+            shape.move(dx, dy);
+        }
+        notifyShapeChanged();
+    }
+
     public void resizeSelectedShape(double x, double y) {
-        if(selectedShape != null){
-            selectedShape.setEnd(x, y);
+        if(selectedShapes.get(0) != null){
+            selectedShapes.get(0).setEnd(x, y);
             notifyShapeChanged();
         }
     }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -93,14 +93,14 @@ public class CanvasModel {
     public void moveSelectedShape(double dx, double dy) {
         if (selectedShape != null) {
             selectedShape.move(dx, dy);
-            // notifyShapeChanged();
+            notifyShapeChanged();
         }
     }
 
     public void resizeSelectedShape(double x, double y) {
         if(selectedShape != null){
             selectedShape.setEnd(x, y);
-            // notifyShapeChanged();
+            notifyShapeChanged();
         }
     }
 }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -22,6 +22,10 @@ public class CanvasModel {
         currentTool = tool;
     }
 
+    public Tool getCurrentTool() {
+        return currentTool;
+    }
+
 
     public void setStart(double x, double y) {
         startX = x;

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -89,4 +89,18 @@ public class CanvasModel {
     public Shape getSelectedShape() {
         return selectedShape;
     }
+
+    public void moveSelectedShape(double dx, double dy) {
+        if (selectedShape != null) {
+            selectedShape.move(dx, dy);
+            // notifyShapeChanged();
+        }
+    }
+
+    public void resizeSelectedShape(double x, double y) {
+        if(selectedShape != null){
+            selectedShape.setEnd(x, y);
+            // notifyShapeChanged();
+        }
+    }
 }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -37,6 +37,9 @@ public class CanvasModel {
     }
 
     public void setCurrentTool(Tool tool) {
+        if(tool == Tool.SELECT){
+            selectedShapes.clear(); //SELECT를 선택하면 단일 선택을 위해 비우기
+        }
         currentTool = tool;
     }
 

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -37,8 +37,8 @@ public class CanvasModel {
     }
 
     public void setCurrentTool(Tool tool) {
-        if(tool == Tool.SELECT){
-            selectedShapes.clear(); //SELECT를 선택하면 단일 선택을 위해 비우기
+        if (currentTool != tool) {
+            selectedShapes.clear();
         }
         currentTool = tool;
     }
@@ -59,21 +59,28 @@ public class CanvasModel {
     }
 
     public void handleClick(double x, double y) {
-        Shape selectedShape = selectShape(x, y);
+        Shape clickedShape = clickShape(x, y);
         if (currentTool == Tool.SELECT) {
-            selectedShapes.clear();
-            if(selectedShape != null){
-                selectedShapes.add(selectedShape);
+            // 빈 공간을 클릭한 경우
+            if (clickedShape == null) {
+                selectedShapes.clear();
+                notifyShapeChanged();
             }
-            
+            // 새로운 도형을 클릭한 경우
+            else if (!selectedShapes.contains(clickedShape)) {
+                selectedShapes.clear();
+                selectedShapes.add(clickedShape);
+                notifyShapeChanged();
+            }
+            // 현재 선택된 도형을 다시 클릭한 경우는 아무 동작 하지 않음
         } 
         else if(currentTool == Tool.MULTI_SELECT){
-            if(selectedShape != null){
-                if(selectedShapes.contains(selectedShape)){
-                    selectedShapes.remove(selectedShape);
+            if(clickedShape != null){
+                if(selectedShapes.contains(clickedShape)){
+                    selectedShapes.remove(clickedShape);
                 }
                 else{
-                    selectedShapes.add(selectedShape);
+                    selectedShapes.add(clickedShape);
                 }
             }
         }
@@ -82,7 +89,7 @@ public class CanvasModel {
         }
     }
 
-    public Shape selectShape(double x, double y) {
+    public Shape clickShape(double x, double y) {
         for (int i = shapes.size() - 1; i >= 0; i--) {
             Shape shape = shapes.get(i);
             if (shape.contains(x, y)) {
@@ -99,25 +106,18 @@ public class CanvasModel {
         if (currentTool != null) {
             newShape.setTool(currentTool);
             shapes.add(newShape);
-            selectedShapes.add(newShape);
             setCurrentTool(Tool.SELECT);
+            selectedShapes.add(newShape);
             notifyShapeChanged();
         }
     }
 
     public Shape getSelectedShape() {
-        return selectedShapes.get(0);
+        return selectedShapes.isEmpty() ? null : selectedShapes.get(0);
     }
 
     public ArrayList<Shape> getSelectedShapes() {
         return selectedShapes;
-    }
-
-    public void moveSelectedShape(double dx, double dy) {
-        if (selectedShapes.get(0) != null) {
-            selectedShapes.get(0).move(dx, dy);
-            notifyShapeChanged();
-        }
     }
 
     public void moveSelectedShapes(double dx, double dy) {
@@ -128,8 +128,9 @@ public class CanvasModel {
     }
 
     public void resizeSelectedShape(double x, double y) {
-        if(selectedShapes.get(0) != null){
-            selectedShapes.get(0).setEnd(x, y);
+        Shape selectedShape = getSelectedShape();
+        if(selectedShape != null){
+            selectedShape.setEnd(x, y);
             notifyShapeChanged();
         }
     }

--- a/app/src/main/java/miridih/objects/Shape.java
+++ b/app/src/main/java/miridih/objects/Shape.java
@@ -41,6 +41,18 @@ public abstract class Shape {
     public abstract boolean contains(double x, double y);
     // public abstract void draw();
 
+    public void move(double dx, double dy) {
+        startX += dx;
+        startY += dy;
+        endX += dx;
+        endY += dy;
+    }
+
+    public boolean isOnHandle(double x, double y) { // 해당 포인트가 끝점 주변 5px 이내에 있는지 확인
+        return Math.abs(x - endX) <= 5 && Math.abs(y - endY) <= 5;
+        
+    }
+
     public double getWidth() {
         return endX - startX;
     }

--- a/app/src/main/java/miridih/objects/Tool.java
+++ b/app/src/main/java/miridih/objects/Tool.java
@@ -1,5 +1,5 @@
 package miridih.objects;
 
 public enum Tool {
-    SELECT, RECTANGLE, ELLIPSE
+    SELECT, RECTANGLE, ELLIPSE, MULTI_SELECT
 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -5,6 +5,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 import java.util.ArrayList;
 
 import javax.swing.JPanel;
@@ -15,6 +16,9 @@ import miridih.objects.Tool;
 
 public class Canvas extends JPanel {
     private final CanvasController canvasController;
+    private double lastX, lastY;
+    private boolean isResizing = false;
+    private boolean isDragging = false;
 
     public Canvas(CanvasController controller) {
         canvasController = controller;
@@ -26,15 +30,35 @@ public class Canvas extends JPanel {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
+                lastX = e.getX();
+                lastY = e.getY();
+
                 canvasController.mousePressed(e.getX(), e.getY());
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
+                
                 canvasController.mouseReleased(e.getX(), e.getY());
                 repaint(); // 마우스 버튼을 놓을 때 도형 그리기
             }
         });
+
+        addMouseMotionListener(new MouseMotionAdapter(){
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if(canvasController.getCurrentTool() == Tool.SELECT) {
+                    if(isResizing){
+
+                    }
+                    else if(isDragging){
+
+                    }
+                    repaint();
+                }
+            }
+        });
+
     }
 
     @Override

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -18,8 +18,6 @@ import miridih.objects.Tool;
 public class Canvas extends JPanel {
     private final CanvasController canvasController;
     private double lastX, lastY;
-    private boolean isResizing = false;
-    private boolean isDragging = false;
 
     public Canvas(CanvasController controller) {
         canvasController = controller;
@@ -31,9 +29,9 @@ public class Canvas extends JPanel {
         addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
+                canvasController.mousePressed(e.getX(), e.getY());
                 lastX = e.getX();
                 lastY = e.getY();
-                canvasController.mousePressed(e.getX(), e.getY());
             }
 
             @Override
@@ -46,20 +44,15 @@ public class Canvas extends JPanel {
         addMouseMotionListener(new MouseMotionAdapter(){
             @Override
             public void mouseDragged(MouseEvent e) {
-
-                if(isResizing){
-                    canvasController.resizeSelectedShape(e.getX(), e.getY());
-                }
-                else if(isDragging && (canvasController.getCurrentTool() == Tool.MULTI_SELECT || 
-                        canvasController.getCurrentTool() == Tool.SELECT)){
-                    canvasController.moveSelectedShapes(e.getX() - lastX, e.getY() - lastY);
-                    lastX = e.getX();
-                    lastY = e.getY();
-                }
+                canvasController.mouseDragged(
+                    e.getX(), 
+                    e.getY(),
+                    e.getX() - lastX,
+                    e.getY() - lastY
+                );
+                lastX = e.getX();
+                lastY = e.getY();
                 repaint();
-                
-                    
-                
             }
         });
 
@@ -70,26 +63,9 @@ public class Canvas extends JPanel {
         super.paintComponent(g);
 
         Graphics2D g2d = (Graphics2D) g;
-
         ArrayList<Shape> shapes = canvasController.getShapes();
 
-        shapes.forEach((shape) -> {
-            Tool tool = shape.getTool();
-            double startX = shape.getStartX();
-            double startY = shape.getStartY();
-            double endX = shape.getEndX();
-            double endY = shape.getEndY();
-
-            switch (tool) {
-                case RECTANGLE:
-                    g2d.drawRect((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
-                    break;
-                case ELLIPSE:
-                    g2d.drawOval((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
-                    break;
-            }
-        });
-
+        shapes.forEach((shape) -> drawShape(g2d, shape));
         ArrayList<Shape> selectedShapes = canvasController.getSelectedShapes();
         for(Shape shape : selectedShapes){
             drawSelectionBox(g2d, shape);
@@ -97,14 +73,30 @@ public class Canvas extends JPanel {
         }
     }
 
+    public void drawShape(Graphics2D g2d, Shape shape){
+        Tool tool = shape.getTool();
+        double startX = shape.getStartX();
+        double startY = shape.getStartY();
+        double endX = shape.getEndX();
+        double endY = shape.getEndY();
+        switch (tool) {
+            case RECTANGLE:
+                g2d.drawRect((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
+                break;
+            case ELLIPSE:
+                g2d.drawOval((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
+                break;
+        }
+    }
+
     public void drawSelectionBox(Graphics2D g2d, Shape selectedShape){
-        g2d.setStroke(new BasicStroke(2));
+        g2d.setStroke(new BasicStroke(1));
         g2d.setColor(Color.BLUE);
         g2d.drawRect((int)selectedShape.getStartX(), (int)selectedShape.getStartY(), (int)(selectedShape.getEndX() - selectedShape.getStartX()), (int)(selectedShape.getEndY() - selectedShape.getStartY()));
     }
 
     public void drawHandle(Graphics2D g2d, Shape selectedShape){
         g2d.setColor(Color.BLUE);
-        g2d.fillRect((int)selectedShape.getEndX() - 5, (int)selectedShape.getEndY() - 5, 10, 10);
+        g2d.fillRect((int)selectedShape.getEndX() - 3, (int)selectedShape.getEndY() - 3, 6, 6);
     }
 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -33,27 +33,11 @@ public class Canvas extends JPanel {
             public void mousePressed(MouseEvent e) {
                 lastX = e.getX();
                 lastY = e.getY();
-
-                if(canvasController.getCurrentTool() == Tool.SELECT ){
-                    Shape selectedShape = canvasController.getSelectedShape();
-                    if(selectedShape != null && selectedShape.isOnHandle(e.getX(), e.getY())){
-                        isResizing = true;
-                    }
-                    else{
-                        isDragging = true;
-                    }
-                }
-                if(canvasController.getCurrentTool() == Tool.MULTI_SELECT){
-                    isDragging = true;
-                }
-                
                 canvasController.mousePressed(e.getX(), e.getY());
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                isResizing = false;
-                isDragging = false;
                 canvasController.mouseReleased(e.getX(), e.getY());
                 repaint(); // 마우스 액션 종료
             }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -33,14 +33,24 @@ public class Canvas extends JPanel {
                 lastX = e.getX();
                 lastY = e.getY();
 
+                if(canvasController.getCurrentTool() == Tool.SELECT ){
+                    Shape selectedShape = canvasController.getSelectedShape();
+                    if(selectedShape != null && selectedShape.isOnHandle(e.getX(), e.getY())){
+                        isResizing = true;
+                    }
+                    else{
+                        isDragging = true;
+                    }
+                }
                 canvasController.mousePressed(e.getX(), e.getY());
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                
+                isResizing = false;
+                isDragging = false;
                 canvasController.mouseReleased(e.getX(), e.getY());
-                repaint(); // 마우스 버튼을 놓을 때 도형 그리기
+                repaint(); // 마우스 액션 종료
             }
         });
 
@@ -49,10 +59,12 @@ public class Canvas extends JPanel {
             public void mouseDragged(MouseEvent e) {
                 if(canvasController.getCurrentTool() == Tool.SELECT) {
                     if(isResizing){
-
+                        canvasController.resizeSelectedShape(e.getX(), e.getY());
                     }
                     else if(isDragging){
-
+                        canvasController.moveSelectedShape(e.getX() - lastX, e.getY() - lastY);
+                        lastX = e.getX();
+                        lastY = e.getY();
                     }
                     repaint();
                 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -1,5 +1,6 @@
 package miridih.view;
 
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -97,5 +98,22 @@ public class Canvas extends JPanel {
                     break;
             }
         });
+
+        Shape selectedShape = canvasController.getSelectedShape();
+        if(selectedShape != null){
+            drawSelectionBox(g2d, selectedShape);
+            drawHandle(g2d, selectedShape);
+        }
+    }
+
+    public void drawSelectionBox(Graphics2D g2d, Shape selectedShape){
+        g2d.setStroke(new BasicStroke(2));
+        g2d.setColor(Color.BLUE);
+        g2d.drawRect((int)selectedShape.getStartX(), (int)selectedShape.getStartY(), (int)(selectedShape.getEndX() - selectedShape.getStartX()), (int)(selectedShape.getEndY() - selectedShape.getStartY()));
+    }
+
+    public void drawHandle(Graphics2D g2d, Shape selectedShape){
+        g2d.setColor(Color.BLUE);
+        g2d.fillRect((int)selectedShape.getEndX() - 5, (int)selectedShape.getEndY() - 5, 10, 10);
     }
 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -43,6 +43,10 @@ public class Canvas extends JPanel {
                         isDragging = true;
                     }
                 }
+                if(canvasController.getCurrentTool() == Tool.MULTI_SELECT){
+                    isDragging = true;
+                }
+                
                 canvasController.mousePressed(e.getX(), e.getY());
             }
 
@@ -58,17 +62,20 @@ public class Canvas extends JPanel {
         addMouseMotionListener(new MouseMotionAdapter(){
             @Override
             public void mouseDragged(MouseEvent e) {
-                if(canvasController.getCurrentTool() == Tool.SELECT) {
-                    if(isResizing){
-                        canvasController.resizeSelectedShape(e.getX(), e.getY());
-                    }
-                    else if(isDragging){
-                        canvasController.moveSelectedShape(e.getX() - lastX, e.getY() - lastY);
-                        lastX = e.getX();
-                        lastY = e.getY();
-                    }
-                    repaint();
+
+                if(isResizing){
+                    canvasController.resizeSelectedShape(e.getX(), e.getY());
                 }
+                else if(isDragging && (canvasController.getCurrentTool() == Tool.MULTI_SELECT || 
+                        canvasController.getCurrentTool() == Tool.SELECT)){
+                    canvasController.moveSelectedShapes(e.getX() - lastX, e.getY() - lastY);
+                    lastX = e.getX();
+                    lastY = e.getY();
+                }
+                repaint();
+                
+                    
+                
             }
         });
 
@@ -99,10 +106,10 @@ public class Canvas extends JPanel {
             }
         });
 
-        Shape selectedShape = canvasController.getSelectedShape();
-        if(selectedShape != null){
-            drawSelectionBox(g2d, selectedShape);
-            drawHandle(g2d, selectedShape);
+        ArrayList<Shape> selectedShapes = canvasController.getSelectedShapes();
+        for(Shape shape : selectedShapes){
+            drawSelectionBox(g2d, shape);
+            drawHandle(g2d, shape);
         }
     }
 

--- a/app/src/main/java/miridih/view/CanvasPanel.java
+++ b/app/src/main/java/miridih/view/CanvasPanel.java
@@ -1,11 +1,11 @@
 package miridih.view;
 
+import java.awt.FlowLayout;
+
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-
-import java.awt.FlowLayout;
 
 import miridih.controller.CanvasController;
 import miridih.observer.ShapeChangeListener;
@@ -58,6 +58,11 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
             yField.setText(String.valueOf(controller.getSelectedShape().getStartY()));
             widthField.setText(String.valueOf(controller.getSelectedShape().getWidth()));
             heightField.setText(String.valueOf(controller.getSelectedShape().getHeight()));
+        } else {
+            xField.setText("");
+            yField.setText("");
+            widthField.setText("");
+            heightField.setText("");
         }
     }
 }

--- a/app/src/main/java/miridih/view/ToolPanel.java
+++ b/app/src/main/java/miridih/view/ToolPanel.java
@@ -17,17 +17,18 @@ public class ToolPanel extends JPanel {
         JButton rectangleButton = new JButton("Rectangle");
         JButton ellipseButton = new JButton("Ellipse");
         JButton selectButton = new JButton("Select");
+        JButton multiSelectButton = new JButton("Multi Select");
 
         // 도구 선택 리스터 추가
         rectangleButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.RECTANGLE));
         ellipseButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.ELLIPSE));
         selectButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.SELECT));
-
+        multiSelectButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.MULTI_SELECT));
         // 패널에 버튼 추가
         toolPanel.add(rectangleButton);
         toolPanel.add(ellipseButton);
         toolPanel.add(selectButton);
-
+        toolPanel.add(multiSelectButton);
         this.add(toolPanel);
     }
 }


### PR DESCRIPTION
### 다중 선택
원래는 단일 선택만 구현하였으나, 다중 선택 구현을 위해서 ArrayList<selectedShapes>로 관리.
TOOL에 MULTI_SELECT를 새로 만들어서, 단일 선택과 다중 선택을 구분함.

단일 선택의 경우, 새로운 도형을 클릭할 때마다 이전에 선택된 도형은 해제되고 새로운 도형이 선택됨.
빈 공간을 클릭할 경우 선택 해제 -> 캔버스패널에 반영하여 아무것도 뜨지 않도록 함.

다중 선택의 경우, 새로운 도형을 클릭할 때마다 selectedShapes에 추가되어 다중 선택이 가능.
이미 선택된 도형을 다시 클릭할 경우 선택 해제.
캔버스패널에는 가장 먼저 선택한 도형의 정보가 노출됨.

툴이 바뀔때마다 선택된 도형은 전부 해제됨

### 크기 조절
크기 조절은 단일 선택 모드에서만 가능. endPoint에만 핸들러를 둠. 
단일 선택 모드에서 도형을 선택하면 외곽선과 핸들러가 생기고, 핸들러를 드래그함으로써 크기 조절 가능.


### 위치 이동
단일 선택의 경우, 선택된 도형을 눌러서 드래그하면 이동이 가능.
다중 선택의 경우, 여러 도형이 선택된 상태로 빈 공간에서 드래그하면 이동이 가능.

### 기타
view에 있던 로직을 controller로 이동함. view는 클릭 이벤트 전달과 그리는 역할만 하도록.

### 필요
현재 Tool을 알려주는 것도 CanvasPanel에 추가하면 좋을듯함
