### PR TITLE
feat : Canvas에도 Listener 적용, Z-order 조절

### DIFF
--- a/app/src/main/java/miridih/App.java
+++ b/app/src/main/java/miridih/App.java
@@ -27,7 +27,7 @@ public class App {
 
             // 패널
             ToolPanel toolPanel = new ToolPanel(canvasController);
-            CanvasPanel canvasPanel = new CanvasPanel(canvasController);
+            CanvasPanel canvasPanel = new CanvasPanel(canvasController, canvas);
             canvasController.addShapeChangeListener(canvasPanel);
 
             frame.add(toolPanel, BorderLayout.WEST);

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -22,16 +22,15 @@ public class CanvasController extends MouseAdapter {
     }
 
     public void mousePressed(double x, double y) {
-        if(getCurrentTool() == Tool.SELECT ){
+        if (getCurrentTool() == Tool.SELECT) {
             Shape selectedShape = getSelectedShape();
-            if(selectedShape != null && selectedShape.isOnHandle(x, y)){
+            if (selectedShape != null && selectedShape.isOnHandle(x, y)) {
                 isResizing = true;
-            }
-            else{
+            } else {
                 isDragging = true;
             }
         }
-        if(getCurrentTool() == Tool.MULTI_SELECT){
+        if (getCurrentTool() == Tool.MULTI_SELECT) {
             isDragging = true;
         }
         canvasModel.setStart(x, y);
@@ -45,10 +44,9 @@ public class CanvasController extends MouseAdapter {
     }
 
     public void mouseDragged(double x, double y, double dx, double dy) {
-        if(isResizing){
+        if (isResizing) {
             resizeSelectedShape(x, y);
-        }
-        else if(isDragging){
+        } else if (isDragging) {
             moveSelectedShapes(dx, dy);
         }
     }
@@ -81,5 +79,10 @@ public class CanvasController extends MouseAdapter {
         canvasModel.moveSelectedShapes(dx, dy);
     }
 
-    
+    public void updateSelectedShape(double x, double y, double width, double height) {
+        Shape selectedShape = getSelectedShape();
+        if (selectedShape != null) {
+            canvasModel.updateShape(selectedShape, x, y, width, height);
+        }
+    }
 }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -1,6 +1,5 @@
 package miridih.controller;
 
-import java.awt.event.MouseAdapter;
 import java.util.ArrayList;
 
 import miridih.model.CanvasModel;
@@ -9,7 +8,7 @@ import miridih.objects.Tool;
 import miridih.observer.ShapeChangeListener;
 import miridih.observer.ToolChangeListener;
 
-public class CanvasController extends MouseAdapter {
+public class CanvasController {
     private final CanvasModel canvasModel;
     private boolean isResizing = false;
     private boolean isDragging = false;

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -89,4 +89,12 @@ public class CanvasController {
             canvasModel.updateShape(selectedShape, x, y, width, height);
         }
     }
+
+    public void bringToFront(Shape shape) {
+        canvasModel.bringToFront(shape);
+    }
+
+    public void sendToBack(Shape shape) {
+        canvasModel.sendToBack(shape);
+    }
 }

--- a/app/src/main/java/miridih/controller/CanvasController.java
+++ b/app/src/main/java/miridih/controller/CanvasController.java
@@ -7,6 +7,7 @@ import miridih.model.CanvasModel;
 import miridih.objects.Shape;
 import miridih.objects.Tool;
 import miridih.observer.ShapeChangeListener;
+import miridih.observer.ToolChangeListener;
 
 public class CanvasController extends MouseAdapter {
     private final CanvasModel canvasModel;
@@ -19,6 +20,10 @@ public class CanvasController extends MouseAdapter {
 
     public void addShapeChangeListener(ShapeChangeListener listener) {
         canvasModel.addShapeChangeListener(listener);
+    }
+
+    public void addToolChangeListener(ToolChangeListener listener) {
+        canvasModel.addToolChangeListener(listener);
     }
 
     public void mousePressed(double x, double y) {

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -76,13 +76,11 @@ public class CanvasModel {
             // 빈 공간을 클릭한 경우
             if (clickedShape == null) {
                 selectedShapes.clear();
-                notifyShapeChanged();
             }
             // 새로운 도형을 클릭한 경우
             else if (!selectedShapes.contains(clickedShape)) {
                 selectedShapes.clear();
                 selectedShapes.add(clickedShape);
-                notifyShapeChanged();
             }
             // 현재 선택된 도형을 다시 클릭한 경우는 아무 동작 하지 않음
         } else if (currentTool == Tool.MULTI_SELECT) {
@@ -96,6 +94,7 @@ public class CanvasModel {
         } else {
             createShape();
         }
+        notifyShapeChanged();
     }
 
     public Shape clickShape(double x, double y) {

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -149,4 +149,16 @@ public class CanvasModel {
         shape.setEnd(x + width, y + height);
         notifyShapeChanged();
     }
+
+    public void bringToFront(Shape shape) {
+        shapes.remove(shape);
+        shapes.add(shape);
+        notifyShapeChanged();
+    }
+
+    public void sendToBack(Shape shape) {
+        shapes.remove(shape);
+        shapes.add(0, shape);
+        notifyShapeChanged();
+    }
 }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -7,13 +7,15 @@ import miridih.factory.ShapeFactory;
 import miridih.objects.Shape;
 import miridih.objects.Tool;
 import miridih.observer.ShapeChangeListener;
+import miridih.observer.ToolChangeListener;
 
 public class CanvasModel {
     private ArrayList<Shape> shapes = new ArrayList<Shape>();
     private ArrayList<Shape> selectedShapes = new ArrayList<Shape>();
     private Tool currentTool = Tool.SELECT;
 
-    private List<ShapeChangeListener> listeners = new ArrayList<>();
+    private List<ShapeChangeListener> shapeChangeListeners = new ArrayList<>();
+    private ArrayList<ToolChangeListener> toolChangeListeners = new ArrayList<>();
 
     // 그리고 있는 도형의 좌표
     private double startX, startY, endX, endY;
@@ -23,16 +25,26 @@ public class CanvasModel {
     }
 
     public void addShapeChangeListener(ShapeChangeListener listener) {
-        listeners.add(listener);
+        shapeChangeListeners.add(listener);
     }
 
     public void removeShapeChangeListener(ShapeChangeListener listener) {
-        listeners.remove(listener);
+        shapeChangeListeners.remove(listener);
     }
 
     private void notifyShapeChanged() {
-        for (ShapeChangeListener listener : listeners) {
+        for (ShapeChangeListener listener : shapeChangeListeners) {
             listener.onShapeChanged();
+        }
+    }
+
+    public void addToolChangeListener(ToolChangeListener listener) {
+        toolChangeListeners.add(listener);
+    }
+
+    private void notifyToolChanged() {
+        for (ToolChangeListener listener : toolChangeListeners) {
+            listener.onToolChanged(currentTool);
         }
     }
 
@@ -41,6 +53,7 @@ public class CanvasModel {
             selectedShapes.clear();
         }
         currentTool = tool;
+        notifyToolChanged();
     }
 
     public Tool getCurrentTool() {
@@ -103,6 +116,7 @@ public class CanvasModel {
             newShape.setTool(currentTool);
             shapes.add(newShape);
             setCurrentTool(Tool.SELECT);
+            selectedShapes.clear();
             selectedShapes.add(newShape);
             notifyShapeChanged();
         }

--- a/app/src/main/java/miridih/model/CanvasModel.java
+++ b/app/src/main/java/miridih/model/CanvasModel.java
@@ -47,7 +47,6 @@ public class CanvasModel {
         return currentTool;
     }
 
-
     public void setStart(double x, double y) {
         startX = x;
         startY = y;
@@ -73,18 +72,15 @@ public class CanvasModel {
                 notifyShapeChanged();
             }
             // 현재 선택된 도형을 다시 클릭한 경우는 아무 동작 하지 않음
-        } 
-        else if(currentTool == Tool.MULTI_SELECT){
-            if(clickedShape != null){
-                if(selectedShapes.contains(clickedShape)){
+        } else if (currentTool == Tool.MULTI_SELECT) {
+            if (clickedShape != null) {
+                if (selectedShapes.contains(clickedShape)) {
                     selectedShapes.remove(clickedShape);
-                }
-                else{
+                } else {
                     selectedShapes.add(clickedShape);
                 }
             }
-        }
-        else {
+        } else {
             createShape();
         }
     }
@@ -121,7 +117,7 @@ public class CanvasModel {
     }
 
     public void moveSelectedShapes(double dx, double dy) {
-        for(Shape shape : selectedShapes){
+        for (Shape shape : selectedShapes) {
             shape.move(dx, dy);
         }
         notifyShapeChanged();
@@ -129,9 +125,15 @@ public class CanvasModel {
 
     public void resizeSelectedShape(double x, double y) {
         Shape selectedShape = getSelectedShape();
-        if(selectedShape != null){
+        if (selectedShape != null) {
             selectedShape.setEnd(x, y);
             notifyShapeChanged();
         }
+    }
+
+    public void updateShape(Shape shape, double x, double y, double width, double height) {
+        shape.setStart(x, y);
+        shape.setEnd(x + width, y + height);
+        notifyShapeChanged();
     }
 }

--- a/app/src/main/java/miridih/observer/ToolChangeListener.java
+++ b/app/src/main/java/miridih/observer/ToolChangeListener.java
@@ -1,0 +1,7 @@
+package miridih.observer;
+
+import miridih.objects.Tool;
+
+public interface ToolChangeListener {
+    void onToolChanged(Tool newTool);
+}

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -41,15 +41,14 @@ public class Canvas extends JPanel {
             }
         });
 
-        addMouseMotionListener(new MouseMotionAdapter(){
+        addMouseMotionListener(new MouseMotionAdapter() {
             @Override
             public void mouseDragged(MouseEvent e) {
                 canvasController.mouseDragged(
-                    e.getX(), 
-                    e.getY(),
-                    e.getX() - lastX,
-                    e.getY() - lastY
-                );
+                        e.getX(),
+                        e.getY(),
+                        e.getX() - lastX,
+                        e.getY() - lastY);
                 lastX = e.getX();
                 lastY = e.getY();
                 repaint();
@@ -67,13 +66,13 @@ public class Canvas extends JPanel {
 
         shapes.forEach((shape) -> drawShape(g2d, shape));
         ArrayList<Shape> selectedShapes = canvasController.getSelectedShapes();
-        for(Shape shape : selectedShapes){
+        for (Shape shape : selectedShapes) {
             drawSelectionBox(g2d, shape);
             drawHandle(g2d, shape);
         }
     }
 
-    public void drawShape(Graphics2D g2d, Shape shape){
+    public void drawShape(Graphics2D g2d, Shape shape) {
         Tool tool = shape.getTool();
         double startX = shape.getStartX();
         double startY = shape.getStartY();
@@ -86,17 +85,25 @@ public class Canvas extends JPanel {
             case ELLIPSE:
                 g2d.drawOval((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
                 break;
+            case MULTI_SELECT:
+                break;
+            case SELECT:
+                break;
+            default:
+                break;
         }
     }
 
-    public void drawSelectionBox(Graphics2D g2d, Shape selectedShape){
+    public void drawSelectionBox(Graphics2D g2d, Shape selectedShape) {
         g2d.setStroke(new BasicStroke(1));
         g2d.setColor(Color.BLUE);
-        g2d.drawRect((int)selectedShape.getStartX(), (int)selectedShape.getStartY(), (int)(selectedShape.getEndX() - selectedShape.getStartX()), (int)(selectedShape.getEndY() - selectedShape.getStartY()));
+        g2d.drawRect((int) selectedShape.getStartX(), (int) selectedShape.getStartY(),
+                (int) (selectedShape.getEndX() - selectedShape.getStartX()),
+                (int) (selectedShape.getEndY() - selectedShape.getStartY()));
     }
 
-    public void drawHandle(Graphics2D g2d, Shape selectedShape){
+    public void drawHandle(Graphics2D g2d, Shape selectedShape) {
         g2d.setColor(Color.BLUE);
-        g2d.fillRect((int)selectedShape.getEndX() - 3, (int)selectedShape.getEndY() - 3, 6, 6);
+        g2d.fillRect((int) selectedShape.getEndX() - 3, (int) selectedShape.getEndY() - 3, 6, 6);
     }
 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -14,14 +14,15 @@ import javax.swing.JPanel;
 import miridih.controller.CanvasController;
 import miridih.objects.Shape;
 import miridih.objects.Tool;
+import miridih.observer.ShapeChangeListener;
 
-public class Canvas extends JPanel {
+public class Canvas extends JPanel implements ShapeChangeListener {
     private final CanvasController canvasController;
     private double lastX, lastY;
 
     public Canvas(CanvasController controller) {
         canvasController = controller;
-
+        canvasController.addShapeChangeListener(this);
         // 배경 색
         setBackground(Color.WHITE);
 
@@ -37,7 +38,6 @@ public class Canvas extends JPanel {
             @Override
             public void mouseReleased(MouseEvent e) {
                 canvasController.mouseReleased(e.getX(), e.getY());
-                repaint(); // 마우스 액션 종료
             }
         });
 
@@ -51,7 +51,6 @@ public class Canvas extends JPanel {
                         e.getY() - lastY);
                 lastX = e.getX();
                 lastY = e.getY();
-                repaint();
             }
         });
 
@@ -112,5 +111,10 @@ public class Canvas extends JPanel {
     public void drawHandle(Graphics2D g2d, Shape selectedShape) {
         g2d.setColor(Color.BLUE);
         g2d.fillRect((int) selectedShape.getEndX() - 3, (int) selectedShape.getEndY() - 3, 6, 6);
+    }
+
+    @Override
+    public void onShapeChanged() {
+        repaint();
     }
 }

--- a/app/src/main/java/miridih/view/Canvas.java
+++ b/app/src/main/java/miridih/view/Canvas.java
@@ -78,11 +78,18 @@ public class Canvas extends JPanel {
         double startY = shape.getStartY();
         double endX = shape.getEndX();
         double endY = shape.getEndY();
+        
         switch (tool) {
             case RECTANGLE:
+                g2d.setColor(Color.WHITE);
+                g2d.fillRect((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
+                g2d.setColor(Color.BLACK);
                 g2d.drawRect((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
                 break;
             case ELLIPSE:
+                g2d.setColor(Color.WHITE);
+                g2d.fillOval((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
+                g2d.setColor(Color.BLACK);
                 g2d.drawOval((int) startX, (int) startY, (int) (endX - startX), (int) (endY - startY));
                 break;
             case MULTI_SELECT:

--- a/app/src/main/java/miridih/view/CanvasPanel.java
+++ b/app/src/main/java/miridih/view/CanvasPanel.java
@@ -3,6 +3,7 @@ package miridih.view;
 import java.awt.FlowLayout;
 
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -32,16 +33,22 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
         yField = createInputField("Y:", 0);
         widthField = createInputField("Width:", 0);
         heightField = createInputField("Height:", 0);
+        JButton bringToFrontBtn = new JButton("Bring to Front");
+        JButton sendToBackBtn = new JButton("Send to Back");
 
         xField.addActionListener(e -> updateShapeFromPanel());
         yField.addActionListener(e -> updateShapeFromPanel());
         widthField.addActionListener(e -> updateShapeFromPanel());
         heightField.addActionListener(e -> updateShapeFromPanel());
+        bringToFrontBtn.addActionListener(e -> bringToFront());
+        sendToBackBtn.addActionListener(e -> sendToBack());
 
         canvasPanel.add(xField.getParent());
         canvasPanel.add(yField.getParent());
         canvasPanel.add(widthField.getParent());
         canvasPanel.add(heightField.getParent());
+        canvasPanel.add(bringToFrontBtn);
+        canvasPanel.add(sendToBackBtn);
 
         this.add(canvasPanel);
     }
@@ -75,6 +82,16 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
                 System.out.println("Invalid input.");
             }
         }
+    }
+
+    private void bringToFront() {
+        Shape selectedShape = controller.getSelectedShape();
+        controller.bringToFront(selectedShape);
+    }
+
+    private void sendToBack() {
+        Shape selectedShape = controller.getSelectedShape();
+        controller.sendToBack(selectedShape);
     }
 
     @Override

--- a/app/src/main/java/miridih/view/CanvasPanel.java
+++ b/app/src/main/java/miridih/view/CanvasPanel.java
@@ -8,6 +8,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import miridih.controller.CanvasController;
+import miridih.objects.Shape;
 import miridih.observer.ShapeChangeListener;
 
 public class CanvasPanel extends JPanel implements ShapeChangeListener {
@@ -15,10 +16,13 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
     private JTextField yField;
     private JTextField widthField;
     private JTextField heightField;
-    private CanvasController controller;
 
-    public CanvasPanel(CanvasController controller) {
+    private CanvasController controller;
+    private Canvas canvas;
+
+    public CanvasPanel(CanvasController controller, Canvas canvas) {
         this.controller = controller;
+        this.canvas = canvas;
         controller.addShapeChangeListener(this);
 
         JPanel canvasPanel = new JPanel();
@@ -28,6 +32,11 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
         yField = createInputField("Y:", 0);
         widthField = createInputField("Width:", 0);
         heightField = createInputField("Height:", 0);
+
+        xField.addActionListener(e -> updateShapeFromPanel());
+        yField.addActionListener(e -> updateShapeFromPanel());
+        widthField.addActionListener(e -> updateShapeFromPanel());
+        heightField.addActionListener(e -> updateShapeFromPanel());
 
         canvasPanel.add(xField.getParent());
         canvasPanel.add(yField.getParent());
@@ -49,6 +58,23 @@ public class CanvasPanel extends JPanel implements ShapeChangeListener {
 
         this.add(panel);
         return textField;
+    }
+
+    private void updateShapeFromPanel() {
+        Shape selectedShape = controller.getSelectedShape();
+        if (selectedShape != null) {
+            try {
+                double x = Double.parseDouble(xField.getText());
+                double y = Double.parseDouble(yField.getText());
+                double width = Double.parseDouble(widthField.getText());
+                double height = Double.parseDouble(heightField.getText());
+
+                controller.updateSelectedShape(x, y, width, height);
+                canvas.repaint();
+            } catch (NumberFormatException e) {
+                System.out.println("Invalid input.");
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/miridih/view/ToolPanel.java
+++ b/app/src/main/java/miridih/view/ToolPanel.java
@@ -1,34 +1,72 @@
 package miridih.view;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
-
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 
 import miridih.controller.CanvasController;
 import miridih.objects.Tool;
+import miridih.observer.ToolChangeListener;
 
-public class ToolPanel extends JPanel {
+public class ToolPanel extends JPanel implements ToolChangeListener {
+    private JButton rectangleButton;
+    private JButton ellipseButton;
+    private JButton selectButton;
+    private JButton multiSelectButton;
+
+    private CanvasController controller;
+
     public ToolPanel(CanvasController controller) {
+        this.controller = controller;
+        controller.addToolChangeListener(this);
+
         JPanel toolPanel = new JPanel();
         toolPanel.setLayout(new BoxLayout(toolPanel, BoxLayout.Y_AXIS));
 
-        JButton rectangleButton = new JButton("Rectangle");
-        JButton ellipseButton = new JButton("Ellipse");
-        JButton selectButton = new JButton("Select");
-        JButton multiSelectButton = new JButton("Multi Select");
+        rectangleButton = createToolButton("Rectangle", Tool.RECTANGLE);
+        ellipseButton = createToolButton("Ellipse", Tool.ELLIPSE);
+        selectButton = createToolButton("Select", Tool.SELECT);
+        multiSelectButton = createToolButton("Multi Select", Tool.MULTI_SELECT);
 
-        // 도구 선택 리스터 추가
-        rectangleButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.RECTANGLE));
-        ellipseButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.ELLIPSE));
-        selectButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.SELECT));
-        multiSelectButton.addActionListener((ActionEvent e) -> controller.setCurrentTool(Tool.MULTI_SELECT));
-        // 패널에 버튼 추가
-        toolPanel.add(rectangleButton);
-        toolPanel.add(ellipseButton);
+        // Add buttons to the panel
         toolPanel.add(selectButton);
         toolPanel.add(multiSelectButton);
+        toolPanel.add(rectangleButton);
+        toolPanel.add(ellipseButton);
         this.add(toolPanel);
+    }
+
+    private JButton createToolButton(String label, Tool tool) {
+        JButton button = new JButton(label);
+        button.addActionListener((ActionEvent e) -> {
+            controller.setCurrentTool(tool);
+            updateButtonColors(button);
+        });
+        button.setFocusPainted(false); // Optional: remove focus border
+        button.setOpaque(true); // Ensure the background color is painted
+
+        return button;
+    }
+
+    // Method to update button colors
+    private void updateButtonColors(JButton selectedButton) {
+        // Reset all buttons to default color
+        rectangleButton.setBackground(null);
+        ellipseButton.setBackground(null);
+        selectButton.setBackground(null);
+        multiSelectButton.setBackground(null);
+
+        // Set the selected button's color to yellow
+        selectedButton.setBackground(Color.YELLOW);
+    }
+
+    @Override
+    public void onToolChanged(Tool newTool) {
+        rectangleButton.setBackground(newTool == Tool.RECTANGLE ? Color.YELLOW : null);
+        ellipseButton.setBackground(newTool == Tool.ELLIPSE ? Color.YELLOW : null);
+        selectButton.setBackground(newTool == Tool.SELECT ? Color.YELLOW : null);
+        multiSelectButton.setBackground(newTool == Tool.MULTI_SELECT ? Color.YELLOW : null);
     }
 }


### PR DESCRIPTION
도형 생성 / 변경에 따라 repaint하는 걸 모델에서 통제하는 게 맞는 흐름같아서 ShapeChangeListener를 Canvas에도 붙여줌

Z-order는 선택된 도형을 맨 앞 또는 맨 뒤로 옮기는 것만 구현
CanvasPanel에 해당 버튼 추가

<img width="793" alt="image" src="https://github.com/user-attachments/assets/4c9caa4e-99e9-4cc1-9f4e-4f3c66fd83a9">
